### PR TITLE
feat: mac perf inputs (v0.2.0) — NDJSON snapshots + powermetrics retarget

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,14 @@
 # cc-edge-the-mac-pack-io
 
-Cribl Edge pack for comprehensive macOS system and power monitoring.
+Cribl Edge pack for comprehensive macOS system, power, and performance monitoring.
+
+The pack targets a **native macOS Cribl Edge install** (Nix-managed). Exec
+inputs that invoke macOS-only binaries (`powermetrics`, `pmset`, `ioreg`,
+`memory_pressure`) require host access and will not work from a Linux
+container. The file input (`mac-perf-snapshots`) reads from a Mac
+filesystem path and likewise requires the native install. An OrbStack-
+deployed Cribl Edge — used elsewhere for cluster monitoring — is unrelated
+to and not used by this pack.
 
 ## Version Policy
 
@@ -19,6 +27,7 @@ This pack uses **semantic versioning**.
 3. Update the `## Release Notes` section in `README.md` with the new version entry
 4. Merge PR to main
 5. Create GitHub release with the `.crbl` artifact built locally:
+
    ```sh
    tar -czf cc-edge-the-mac-pack-io-vX.Y.Z.crbl data default package.json README.md
    cp cc-edge-the-mac-pack-io-vX.Y.Z.crbl cc-edge-the-mac-pack-io.crbl

--- a/README.md
+++ b/README.md
@@ -1,18 +1,31 @@
 # cc-edge-the-mac-pack-io
 
-Cribl Edge Pack for comprehensive macOS system and power monitoring.
+Cribl Edge Pack for comprehensive macOS system, power, and performance monitoring.
 
 > Supersedes `cc-edge-macos-system` and `cc-edge-macos-power` — both repos are archived.
 
 ## Overview
 
-Collects macOS system health and power data via native system tools using Cribl Edge Exec sources. Covers CPU, memory, disk, virtual memory, process stats, thermal state, WindowServer health, Jetsam events, per-process energy impact, and battery lifecycle. All events flow through Cribl Stream into Splunk (or any destination).
+Collects macOS system health, power, and performance data via native system tools using Cribl Edge
+Exec sources, plus full host snapshots tailed from NDJSON files via Cribl File sources.
 
-This pack is the macOS equivalent of Splunk's Splunk_TA_nix and Splunk_TA_windows — delivering comprehensive operating system telemetry via Cribl Edge instead of scripted inputs on the Splunk forwarder.
+Covers CPU, memory, disk, virtual memory, process stats, thermal state, WindowServer health,
+Jetsam events, per-process energy impact, ANE/GPU/CPU power, battery lifecycle, and aggregate host
+perf snapshots (load, RSS top, zombies, sleep assertions, crashes, listening ports).
+
+Events flow through Cribl Stream into Splunk (or any destination).
+
+This pack is the macOS equivalent of Splunk's Splunk_TA_nix and Splunk_TA_windows — delivering
+comprehensive operating system telemetry via Cribl Edge instead of scripted inputs on the Splunk
+forwarder.
 
 ## Origin Story
 
-This pack was born from a real incident: a 60-second MacBook UI freeze went undetected because WindowServer ping timeout events required manual log forensics to discover. The `macos-windowserver-health` source is the highest-priority data source in this pack, turning what was previously invisible into a first-class observable signal.
+This pack was born from a real incident: a 60-second MacBook UI freeze went undetected because
+WindowServer ping timeout events required manual log forensics to discover.
+
+The `macos-windowserver-health` source is the highest-priority data source in this pack, turning
+what was previously invisible into a first-class observable signal.
 
 ## Data Sources
 
@@ -78,8 +91,10 @@ This pack was born from a real incident: a 60-second MacBook UI freeze went unde
 ### Power Metrics (`macos-power-metrics`)
 
 - **Interval**: 300 seconds (5 minutes)
-- **Command**: `powermetrics --samplers tasks,battery,cpu_power,gpu_power,ane_power,thermal --show-process-energy -f plist -n 1 -i 5000 | plutil -convert json -o - -`
-- **Sourcetype**: `macos:power:metrics`
+- **Command**: `powermetrics --samplers tasks,battery,cpu_power,gpu_power,ane_power,thermal ...`
+  piped through `plutil -convert json` — full command in [`default/inputs.yml`](default/inputs.yml)
+- **Sourcetype**: `macos:perf:powermetrics` (changed in v0.2.0; was `macos:power:metrics` in v0.1.0)
+- **Index**: `mac_perf` (changed in v0.2.0; was `os` in v0.1.0)
 - **Captures**: Per-process energy impact (top 10), CPU package power (mW), GPU power, ANE power, thermal pressure state, processor frequency
 - **Anomaly**: `thermal_pressure !== 'Nominal'` sets `anomaly=true`
 - **Requires**: Root privileges
@@ -94,16 +109,38 @@ This pack was born from a real incident: a 60-second MacBook UI freeze went unde
 - **Anomaly**: `battery_health_percent < 80` sets `anomaly=true`
 - **Requires**: No special privileges
 
+### Perf Snapshots (`mac-perf-snapshots`) — File Source
+
+- **Interval**: 30 seconds (file poll)
+- **Source**: NDJSON files at `$MAC_PERF_SNAPSHOTS_DIR` (one event per line)
+- **Sourcetype**: `macos:perf:snapshot`
+- **Index**: `mac_perf`
+- **Captures**: Aggregate host perf snapshot — load averages, memory totals, swap I/O,
+  top CPU/RSS processes, zombie process tree, sleep assertions, 24h crash counts,
+  listening ports, logged-in users, kernel_task CPU%
+- **Producer**: Standalone Python collector (e.g., `nix-mac-performance/monitoring/collect-snapshot.py`)
+  writing daily-rotated `<YYYY-MM-DD>.ndjson` files via a per-user LaunchAgent on a 5-minute cadence
+- **Time extraction**: `_time` is set from the `ts` field in each event (ISO 8601 UTC), not Cribl ingestion time
+- **Requires**: Read access to the snapshot directory; no special privileges
+
 ## Data Flow
 
-```
+```text
 memory_pressure / log / top / iostat / vm_stat / pmset / powermetrics / ioreg
-    |
-Cribl Edge (native macOS, /opt/cribl/)
-    |  HEC
-Cribl Stream
-    |  HEC
-Splunk -> index: os, sourcetype: macos:system:{type} or macos:power:{type}
+    |  (Cribl Exec sources)
+    +----------------------------+
+collect-snapshot.py NDJSON files  |
+    |  (Cribl File source)       |
+    +----------------------------+
+                                  |
+                  Cribl Edge (native macOS, /opt/cribl/)
+                                  |  HEC
+                            Cribl Stream
+                                  |  HEC
+                                  v
+        Splunk:
+          index=os         sourcetype=macos:system:* | macos:power:battery
+          index=mac_perf   sourcetype=macos:perf:powermetrics | macos:perf:snapshot
 ```
 
 ## Anomaly Detection
@@ -121,13 +158,24 @@ The pipeline automatically flags anomalous events with `anomaly=true` and `anoma
 Use these fields in Splunk (or any destination) to build alerts:
 
 ```spl
-index=os sourcetype=macos:system:* OR sourcetype=macos:power:* anomaly=true
+(index=os OR index=mac_perf) (sourcetype=macos:system:* OR sourcetype=macos:power:* OR sourcetype=macos:perf:*) anomaly=true
 | stats count by host, anomaly_reason, _time
 ```
 
 ## Usage
 
-Once installed, the pack automatically collects data on the configured intervals. All system sources use `macos:system:*` sourcetypes; power/battery sources use `macos:power:*` sourcetypes. All events go to the `os` index.
+Once installed, the pack automatically collects data on the configured intervals.
+
+| Sourcetype namespace | Index | Source type |
+| --- | --- | --- |
+| `macos:system:*` | `os` | Exec |
+| `macos:power:battery` | `os` | Exec |
+| `macos:perf:powermetrics` | `mac_perf` | Exec |
+| `macos:perf:snapshot` | `mac_perf` | File (NDJSON) |
+
+The file-based snapshot input requires the `MAC_PERF_SNAPSHOTS_DIR` environment variable to be
+set on the Cribl Edge worker, pointing at the directory where the snapshot collector writes its
+NDJSON files (e.g., `/Users/<you>/git/nix-mac-performance/main/monitoring/snapshots`).
 
 To customize, create local overrides in `/opt/cribl/local/cc-edge-the-mac-pack-io/`:
 
@@ -140,6 +188,8 @@ inputs:
     disabled: true  # Disable if root unavailable
   macos-power-metrics:
     disabled: true  # Disable if root unavailable
+  mac-perf-snapshots:
+    disabled: true  # Disable if no external collector is running
 ```
 
 ## Installation
@@ -217,9 +267,9 @@ inputs:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| index | string | Always `os` |
-| sourcetype | string | `macos:system:{type}` or `macos:power:{type}` |
-| host | string | Hostname of the Edge node |
+| index | string | `os` for system + battery sources; `mac_perf` for perf sources |
+| sourcetype | string | `macos:system:{type}`, `macos:power:battery`, `macos:perf:powermetrics`, or `macos:perf:snapshot` |
+| host | string | Hostname of the Edge node (or the snapshot event's `host` for file-source events) |
 | anomaly | boolean | `true` when anomaly detected (absent otherwise) |
 | anomaly_reason | string | Anomaly type identifier (absent when no anomaly) |
 
@@ -237,11 +287,36 @@ inputs:
 
 ## Release Notes
 
+### v0.2.0 (2026-04-29)
+
+- **New File input** `mac-perf-snapshots` — tails NDJSON files emitted by an external snapshot
+  collector (such as `nix-mac-performance/monitoring/collect-snapshot.py`).
+  Reads `*.ndjson` from `$MAC_PERF_SNAPSHOTS_DIR`, parses each JSON line, sets `_time` from the
+  event's `ts` field, routes to `index=mac_perf` with sourcetype `macos:perf:snapshot`.
+- **Powermetrics retargeted** — the existing `macos-power-metrics` Exec input now writes to
+  `index=mac_perf` with sourcetype `macos:perf:powermetrics`.
+  **BREAKING** for any v0.1.0 dashboards or alerts that filtered
+  `index=os sourcetype=macos:power:metrics`; update saved searches accordingly.
+- **New `perf` streamtag** added to pack metadata.
+- **Sample queries:**
+
+  ```spl
+  index=mac_perf sourcetype="macos:perf:snapshot" earliest=-1h | head 5
+  index=mac_perf sourcetype="macos:perf:powermetrics" earliest=-1h | head 5
+  ```
+
+- **Prerequisites for v0.2.0:**
+  - Splunk index `mac_perf` exists (provisioned by ansible-splunk).
+  - Splunk add-on `VisiCore_TA_AI_Observability` includes `[macos:perf:snapshot]` and `[macos:perf:powermetrics]` props.
+  - For the file input to have data: a snapshot collector must be installed on the Mac (e.g., `nix-mac-performance` PR #2 LaunchAgent).
+  - Cribl Edge worker has `MAC_PERF_SNAPSHOTS_DIR` env var set.
+
 ### v0.1.0 (2026-04-18)
 
 - **Initial release** of `cc-edge-the-mac-pack-io` — consolidates `cc-edge-macos-system` and `cc-edge-macos-power` (both predecessor repos archived)
 - **Nine Exec inputs**:
-  - System monitoring: WindowServer health (60s), memory pressure (60s), Jetsam events (5min), process stats (60s), disk I/O (60s), VM stats (60s), thermal status (60s)
+  - System monitoring: WindowServer health (60s), memory pressure (60s), Jetsam events (5min),
+    process stats (60s), disk I/O (60s), VM stats (60s), thermal status (60s)
   - Power monitoring: per-process energy metrics + thermal (300s), battery health (60s)
 - **Anomaly detection** for: memory pressure, WindowServer timeouts, Jetsam events, battery health degradation, thermal pressure elevation
 - **Sourcetype namespaces**: `macos:system:*` and `macos:power:*`

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ inputs:
 | memoryStatus | object | System memory status including page counts and compressor stats |
 | processes | array | List of processes with memory details and states |
 
-### Power Metrics Events (`macos:power:metrics`)
+### Power Metrics Events (`macos:perf:powermetrics`)
 
 | Field | Type | Description |
 |-------|------|-------------|

--- a/default/inputs.yml
+++ b/default/inputs.yml
@@ -106,3 +106,18 @@ inputs:
     metadata:
       - name: datatype
         value: "'macos-power-battery'"
+
+  mac-perf-snapshots:
+    type: file
+    disabled: false
+    sendToRoutes: true
+    pqEnabled: false
+    streamtags: []
+    path: "$MAC_PERF_SNAPSHOTS_DIR"
+    filenames:
+      - "*.ndjson"
+    tailOnly: false
+    interval: 30
+    metadata:
+      - name: datatype
+        value: "'macos-perf-snapshot'"

--- a/default/pipelines/main.yml
+++ b/default/pipelines/main.yml
@@ -18,14 +18,14 @@ conf:
           - name: sourcetype
             value: "datatype === 'macos-power-metrics' ? 'macos:perf:powermetrics' : (datatype === 'macos-perf-snapshot' ? 'macos:perf:snapshot' : (datatype ? datatype.replace('macos-power-', 'macos:power:').replace('macos-system-', 'macos:system:') : ''))"
           - name: host
-            value: "C.os.hostname()"
+            value: "host || C.os.hostname()"
     - id: eval
       filter: "datatype === 'macos-perf-snapshot' && ts"
       disabled: false
       conf:
         add:
           - name: _time
-            value: "(new Date(ts)).getTime() / 1000"
+            value: "C.Time.parse(ts)"
     - id: eval
       filter: "datatype === 'macos-system-memory'"
       disabled: false

--- a/default/pipelines/main.yml
+++ b/default/pipelines/main.yml
@@ -1,17 +1,31 @@
 id: main
 conf:
   functions:
+    - id: parser
+      filter: "datatype === 'macos-perf-snapshot'"
+      disabled: false
+      conf:
+        mode: extract
+        type: json
+        srcField: _raw
     - id: eval
       filter: "true"
       disabled: false
       conf:
         add:
           - name: index
-            value: "'os'"
+            value: "(datatype === 'macos-power-metrics' || datatype === 'macos-perf-snapshot') ? 'mac_perf' : 'os'"
           - name: sourcetype
-            value: "datatype ? datatype.replace('macos-power-', 'macos:power:').replace('macos-system-', 'macos:system:') : ''"
+            value: "datatype === 'macos-power-metrics' ? 'macos:perf:powermetrics' : (datatype === 'macos-perf-snapshot' ? 'macos:perf:snapshot' : (datatype ? datatype.replace('macos-power-', 'macos:power:').replace('macos-system-', 'macos:system:') : ''))"
           - name: host
             value: "C.os.hostname()"
+    - id: eval
+      filter: "datatype === 'macos-perf-snapshot' && ts"
+      disabled: false
+      conf:
+        add:
+          - name: _time
+            value: "(new Date(ts)).getTime() / 1000"
     - id: eval
       filter: "datatype === 'macos-system-memory'"
       disabled: false

--- a/default/pipelines/route.yml
+++ b/default/pipelines/route.yml
@@ -92,3 +92,13 @@ routes:
     filter: __inputId=='exec:cc-edge-the-mac-pack-io.macos-power-battery'
     clones: []
     output: default
+  - id: mac-perf-snapshots
+    name: macOS Perf Snapshots (NDJSON File)
+    final: true
+    disabled: false
+    pipeline: main
+    description: "macOS perf snapshots tailed from NDJSON files emitted by collect-snapshot.py"
+    enableOutputExpression: false
+    filter: __inputId=='file:cc-edge-the-mac-pack-io.mac-perf-snapshots'
+    clones: []
+    output: default

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-edge-the-mac-pack-io",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "minLogStreamVersion": "4.16.0",
   "author": "VisiCore Tech - CriblPacks@VisiCoreTech.com",
-  "description": "Cribl Edge Pack for comprehensive macOS system monitoring: memory pressure, WindowServer health, Jetsam events, process stats, disk I/O, VM stats, thermal status, per-process power/energy metrics, and battery health — with anomaly detection.",
-  "displayName": "The Mac Pack — macOS System & Power Monitoring for Edge",
+  "description": "Cribl Edge Pack for comprehensive macOS system, power, and performance telemetry: memory pressure, WindowServer health, Jetsam events, process stats, disk I/O, VM stats, thermal status, ANE/GPU/CPU power metrics, battery health, and full perf snapshots — with anomaly detection.",
+  "displayName": "The Mac Pack — macOS System, Power & Performance Monitoring for Edge",
   "tags": {
-    "streamtags": ["vct", "macos", "system", "power", "battery", "monitoring"],
+    "streamtags": ["vct", "macos", "system", "power", "battery", "perf", "monitoring"],
     "dataType": ["metrics", "logs"]
   },
   "exports": []


### PR DESCRIPTION
## Summary

- ✨ New `mac-perf-snapshots` File source tails NDJSON snapshots from `$MAC_PERF_SNAPSHOTS_DIR`. Pipeline parses each JSON line, sets `_time` from the event's `ts`, routes to `index=mac_perf` with sourcetype `macos:perf:snapshot`.
- 🔥 **BREAKING** — `macos-power-metrics` Exec input retargeted from `index=os` / `sourcetype=macos:power:metrics` to `index=mac_perf` / `sourcetype=macos:perf:powermetrics`. v0.1.0 dashboards/alerts on the old sourcetype must be updated.
- 🏷️ Adds `perf` streamtag; bumps version 0.1.0 → 0.2.0.
- 📝 README expanded with new data-source section, sourcetype/index map, sample queries, breaking-change notes.

## Coordinated changes (separate PRs)

- `JacobPEvans/ansible-splunk` — append `mac_perf` to `splunk_docker_indexes`. HEC token auto-derives.
- `JacobPEvans/VisiCore_TA_AI_Observability` — add `[macos:perf:snapshot]` and `[macos:perf:powermetrics]` props.
- `JacobPEvans/nix-mac-performance` PR #2 (collector LaunchAgent) — must merge & install for the file input to have data.

## Test plan

- [ ] CI: `_cribl-pack-validate.yml` reusable workflow passes (YAML schema + structure)
- [ ] Local: `ruby -ryaml -e ...` confirms 10 inputs / 10 routes / 8 pipeline functions
- [ ] After merge + ansible-splunk merge: build .crbl, install in Cribl Cloud, set `MAC_PERF_SNAPSHOTS_DIR` env var on Mac Edge, run `python3 nix-mac-performance/monitoring/collect-snapshot.py` to seed an NDJSON line
- [ ] Splunk: `index=mac_perf sourcetype="macos:perf:snapshot" earliest=-1h | head 5` returns ≥1 event with correct `_time` extraction
- [ ] Splunk: `index=mac_perf sourcetype="macos:perf:powermetrics" earliest=-1h | head 5` returns ≥1 event after the next 300s exec interval

(claude)