### PR TITLE
feat(v0.3.0): adopt Cribl 4.18 native macOS sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,107 +6,94 @@ Cribl Edge Pack for comprehensive macOS system, power, and performance monitorin
 
 ## Overview
 
-Collects macOS system health, power, and performance data via native system tools using Cribl Edge
-Exec sources, plus full host snapshots tailed from NDJSON files via Cribl File sources.
+Collects macOS telemetry on a Cribl Edge Node running natively on macOS. As of v0.3.0
+the pack uses Cribl 4.18's native macOS Sources for broad host-metrics and Unified-Log
+capture, falling back to Exec sources only for data the native Sources don't yet expose
+(per-process energy via `powermetrics`, battery cycle/health via `ioreg`, and macOS
+thermal pressure via `pmset`).
 
-Covers CPU, memory, disk, virtual memory, process stats, thermal state, WindowServer health,
-Jetsam events, per-process energy impact, ANE/GPU/CPU power, battery lifecycle, and aggregate host
-perf snapshots (load, RSS top, zombies, sleep assertions, crashes, listening ports).
+Design rule: **Edge captures broadly, Stream filters.** Source-level predicates that
+narrow to specific use cases (WindowServer ping detection, Jetsam triage, security event
+extraction, etc.) belong in Stream-side pipelines downstream of Edge — not in this pack.
 
 Events flow through Cribl Stream into Splunk (or any destination).
 
-This pack is the macOS equivalent of Splunk's Splunk_TA_nix and Splunk_TA_windows — delivering
-comprehensive operating system telemetry via Cribl Edge instead of scripted inputs on the Splunk
-forwarder.
+This pack is the macOS equivalent of Splunk's Splunk_TA_nix and Splunk_TA_windows —
+delivering comprehensive operating system telemetry via Cribl Edge instead of scripted
+inputs on a forwarder.
 
 ## Origin Story
 
-This pack was born from a real incident: a 60-second MacBook UI freeze went undetected because
-WindowServer ping timeout events required manual log forensics to discover.
+This pack was born from a real incident: a 60-second MacBook UI freeze went undetected
+because WindowServer ping timeout events required manual log forensics to discover.
 
-The `macos-windowserver-health` source is the highest-priority data source in this pack, turning
-what was previously invisible into a first-class observable signal.
+In v0.1–v0.2 the pack ran a tightly-filtered `log show ... WindowServer ... ping` exec
+loop. In v0.3 that filtering moves to Stream — the Edge now captures the full Apple
+Unified Log stream broadly, and Stream pipelines extract the ping-timeout signal (and
+any other subsystem-of-interest) downstream.
 
 ## Data Sources
 
-### WindowServer Health (`macos-windowserver-health`) — PRIMARY
+### Apple Unified Logs (`in_apple_unified_logs`) — Native 4.18 Source
 
-- **Interval**: 60 seconds
-- **Command**: `/usr/bin/log show --last 65s` filtering for WindowServer ping events
-- **Sourcetype**: `macos:system:windowserver`
-- **Captures**: WindowServer ping timeout events indicating UI freezes, affected PIDs
-- **Anomaly**: Any ping timeout event sets `anomaly=true`
-- **Requires**: No special privileges
+- **Type**: `apple_unified_logs` (macOS Edge only)
+- **Polling**: 5 second internal poll (Cribl-managed)
+- **Predicate**: `subsystem BEGINSWITH "com.apple"` — broad capture of every Apple
+  subsystem (kernel, WindowServer, security, network, power, Spotlight, Time Machine,
+  TCC, sandbox, launchservices, xpc, etc.). Override to `TRUEPREDICATE` for 3rd-party
+  app logs as well.
+- **Read mode**: `lastEntry` (new entries only on (re)start). Switch to `allEvents` for
+  historical backfill.
+- **Sourcetype** (assigned in pipeline): `macos:unified_log`
+- **Index**: `os`
+- **Replaces**: v0.2 exec sources `macos-windowserver-health` and `macos-jetsam-events`.
+  Filtering for those specific signals now lives in Stream pipelines.
 
-### Memory Pressure (`macos-memory-pressure`)
+### System Metrics (`in_system_metrics`) — Native 4.18 Source
 
-- **Interval**: 60 seconds
-- **Command**: `memory_pressure`
-- **Sourcetype**: `macos:system:memory`
-- **Captures**: Pages free/active/inactive/wired/compressed, swap I/O, system-wide free percentage
-- **Anomaly**: `memory_free_pct < 10` sets `anomaly=true`
-- **Requires**: No special privileges
+- **Type**: `system_metrics` (Linux + macOS Edge)
+- **Polling**: 60 seconds
+- **Collectors**: CPU, memory, disk, network, system, process (configure detail level
+  per category in Cribl UI). Container + GPU collectors stay disabled on macOS.
+- **Sourcetype** (assigned in pipeline): `macos:system:metrics`
+- **Index**: `mac_perf`
+- **Replaces**: v0.2 exec sources `macos-memory-pressure`, `macos-vm-stat`,
+  `macos-disk-io`, `macos-process-top`.
 
-### Jetsam Events (`macos-jetsam-events`)
-
-- **Interval**: 300 seconds (5 minutes)
-- **Command**: Bash script to find and parse latest JetsamEvent `.ips` file
-- **Sourcetype**: `macos:system:jetsam`
-- **Captures**: Jetsam kill events including largest process, memory page counts, killed process list
-- **Anomaly**: Presence of a recent Jetsam event sets `anomaly=true`
-- **Requires**: Read access to `/Library/Logs/DiagnosticReports/`
-
-### Process Stats (`macos-process-top`)
-
-- **Interval**: 60 seconds
-- **Command**: `top -l 1 -n 20 -stats pid,command,cpu,mem,rprvt,purg,vsize,threads`
-- **Sourcetype**: `macos:system:process`
-- **Captures**: Top 20 processes by CPU with memory, resident private, purgeable, virtual size, and thread counts
-- **Requires**: Root privileges
-
-### Disk I/O (`macos-disk-io`)
-
-- **Interval**: 60 seconds
-- **Command**: `iostat -d -c 2 -w 1`
-- **Sourcetype**: `macos:system:diskio`
-- **Captures**: Disk throughput (KB/t), transactions per second (tps), bandwidth (MB/s)
-- **Requires**: No special privileges
-
-### VM Statistics (`macos-vm-stat`)
-
-- **Interval**: 60 seconds
-- **Command**: `vm_stat`
-- **Sourcetype**: `macos:system:vmstat`
-- **Captures**: Detailed virtual memory statistics including page faults, compressor activity, purgeable pages, copy-on-write, swap I/O
-- **Requires**: No special privileges
-
-### Thermal Status (`macos-thermal`)
+### Thermal Status (`macos-thermal`) — Exec Source
 
 - **Interval**: 60 seconds
 - **Command**: `pmset -g therm`
 - **Sourcetype**: `macos:system:thermal`
 - **Captures**: Thermal warning level, performance warning level, CPU power status
+- **Why exec**: System Metrics Source on macOS doesn't yet surface system-wide thermal
+  pressure / CPU power throttling state.
 - **Requires**: No special privileges
 
-### Power Metrics (`macos-power-metrics`)
+### Power Metrics (`macos-power-metrics`) — Exec Source
 
 - **Interval**: 300 seconds (5 minutes)
 - **Command**: `powermetrics --samplers tasks,battery,cpu_power,gpu_power,ane_power,thermal ...`
   piped through `plutil -convert json` — full command in [`default/inputs.yml`](default/inputs.yml)
-- **Sourcetype**: `macos:perf:powermetrics` (changed in v0.2.0; was `macos:power:metrics` in v0.1.0)
-- **Index**: `mac_perf` (changed in v0.2.0; was `os` in v0.1.0)
-- **Captures**: Per-process energy impact (top 10), CPU package power (mW), GPU power, ANE power, thermal pressure state, processor frequency
+- **Sourcetype**: `macos:perf:powermetrics`
+- **Index**: `mac_perf`
+- **Captures**: Per-process energy impact (top 10), CPU package power (mW), GPU power,
+  ANE power, thermal pressure state, processor frequency
 - **Anomaly**: `thermal_pressure !== 'Nominal'` sets `anomaly=true`
+- **Why exec**: No native 4.18 Source exposes per-process energy / ANE power.
 - **Requires**: Root privileges
 
-### Battery Health (`macos-power-battery`)
+### Battery Health (`macos-power-battery`) — Exec Source
 
 - **Interval**: 60 seconds
 - **Command**: Bash combining `pmset -g batt` + `ioreg -r -c AppleSmartBattery`
 - **Sourcetype**: `macos:power:battery`
-- **Captures**: Charge percentage, power source (AC/Battery), charging state, cycle count, max/design/current capacity, temperature, voltage
+- **Captures**: Charge percentage, power source (AC/Battery), charging state,
+  cycle count, max/design/current capacity, temperature, voltage
 - **Derived**: `battery_health_percent = max_capacity / design_capacity × 100`
 - **Anomaly**: `battery_health_percent < 80` sets `anomaly=true`
+- **Why exec**: No native Source exposes battery cycle count / design capacity /
+  IOKit `AppleSmartBattery` properties.
 - **Requires**: No special privileges
 
 ### Perf Snapshots (`mac-perf-snapshots`) — File Source
@@ -119,77 +106,88 @@ what was previously invisible into a first-class observable signal.
   top CPU/RSS processes, zombie process tree, sleep assertions, 24h crash counts,
   listening ports, logged-in users, kernel_task CPU%
 - **Producer**: Standalone Python collector (e.g., `nix-mac-performance/monitoring/collect-snapshot.py`)
-  writing daily-rotated `<YYYY-MM-DD>.ndjson` files via a per-user LaunchAgent on a 5-minute cadence
-- **Time extraction**: `_time` is set from the `ts` field in each event (ISO 8601 UTC), not Cribl ingestion time
+  writing daily-rotated `<YYYY-MM-DD>.ndjson` files via a per-user LaunchAgent on a
+  5-minute cadence
+- **Time extraction**: `_time` is set from the `ts` field in each event (ISO 8601 UTC),
+  not Cribl ingestion time
 - **Requires**: Read access to the snapshot directory; no special privileges
 
 ## Data Flow
 
 ```text
-memory_pressure / log / top / iostat / vm_stat / pmset / powermetrics / ioreg
-    |  (Cribl Exec sources)
-    +----------------------------+
-collect-snapshot.py NDJSON files  |
-    |  (Cribl File source)       |
-    +----------------------------+
-                                  |
-                  Cribl Edge (native macOS, /opt/cribl/)
-                                  |  HEC
-                            Cribl Stream
-                                  |  HEC
-                                  v
-        Splunk:
-          index=os         sourcetype=macos:system:* | macos:power:battery
-          index=mac_perf   sourcetype=macos:perf:powermetrics | macos:perf:snapshot
+Apple Unified Logging                                    Cribl native
+   subsystem BEGINSWITH "com.apple"        ┐              4.18 Source
+macOS kernel/system metrics                ┤
+   CPU, memory, disk, network, processes   ┘
+pmset / powermetrics / ioreg               ┐              Cribl Exec
+                                           ┤              + File
+collect-snapshot.py NDJSON files           ┘              Sources
+                       │
+                       ▼
+                 Cribl Edge (native macOS, /opt/cribl/)
+                       │ TLS
+                       ▼
+                 Cribl Stream (per-use-case routing/filtering happens here)
+                       │ HEC
+                       ▼
+                 Splunk:
+                   index=os         sourcetype=macos:unified_log | macos:system:thermal
+                                    | macos:power:battery
+                   index=mac_perf   sourcetype=macos:system:metrics | macos:perf:powermetrics
+                                    | macos:perf:snapshot
 ```
 
 ## Anomaly Detection
 
-The pipeline automatically flags anomalous events with `anomaly=true` and `anomaly_reason`:
+Edge keeps anomaly detection ONLY for events that come from the exec sources
+(powermetrics, battery). Anomaly detection for memory pressure, WindowServer ping
+timeouts, and Jetsam events moves to Stream — the broad Apple Unified Logs / System
+Metrics streams already carry the underlying data; Stream pipelines extract the signal.
 
-| Condition | anomaly_reason |
-|-----------|----------------|
-| Memory free < 10% | `memory_pressure_critical` |
-| Any WindowServer ping timeout | `windowserver_ping_timeout` |
-| Recent Jetsam event detected | `jetsam_event_detected` |
-| Battery health < 80% | `battery_health_degraded` |
-| Thermal pressure not Nominal | `thermal_pressure_elevated` |
+| Condition | anomaly_reason | Detected at |
+|-----------|----------------|-------------|
+| Battery health < 80% | `battery_health_degraded` | Edge (this pack) |
+| Thermal pressure not Nominal | `thermal_pressure_elevated` | Edge (this pack) |
+| Memory pressure critical | (Stream-side, future) | Stream |
+| WindowServer ping timeout | (Stream-side, future) | Stream |
+| Jetsam event | (Stream-side, future) | Stream |
 
-Use these fields in Splunk (or any destination) to build alerts:
+Use these fields in Splunk to alert on what Edge does flag:
 
 ```spl
-(index=os OR index=mac_perf) (sourcetype=macos:system:* OR sourcetype=macos:power:* OR sourcetype=macos:perf:*) anomaly=true
+(index=os OR index=mac_perf) anomaly=true
 | stats count by host, anomaly_reason, _time
 ```
 
 ## Usage
 
-Once installed, the pack automatically collects data on the configured intervals.
-
 | Sourcetype namespace | Index | Source type |
 | --- | --- | --- |
-| `macos:system:*` | `os` | Exec |
+| `macos:unified_log` | `os` | Native (apple_unified_logs) |
+| `macos:system:metrics` | `mac_perf` | Native (system_metrics) |
+| `macos:system:thermal` | `os` | Exec |
 | `macos:power:battery` | `os` | Exec |
 | `macos:perf:powermetrics` | `mac_perf` | Exec |
 | `macos:perf:snapshot` | `mac_perf` | File (NDJSON) |
 
-The file-based snapshot input requires the `MAC_PERF_SNAPSHOTS_DIR` environment variable to be
-set on the Cribl Edge worker, pointing at the directory where the snapshot collector writes its
-NDJSON files (e.g., `/Users/<you>/git/nix-mac-performance/main/monitoring/snapshots`).
+The file-based snapshot input requires the `MAC_PERF_SNAPSHOTS_DIR` environment variable
+to be set on the Cribl Edge worker, pointing at the directory where the snapshot
+collector writes its NDJSON files
+(e.g., `/Users/<you>/git/nix-mac-performance/main/monitoring/snapshots`).
 
 To customize, create local overrides in `/opt/cribl/local/cc-edge-the-mac-pack-io/`:
 
 ```yaml
 # /opt/cribl/local/cc-edge-the-mac-pack-io/inputs.yml
 inputs:
-  macos-windowserver-health:
-    interval: 30  # Check more frequently for UI freezes
-  macos-process-top:
-    disabled: true  # Disable if root unavailable
+  in_apple_unified_logs:
+    predicate: 'TRUEPREDICATE'   # capture 3rd-party app logs too
+  in_system_metrics:
+    pollingInterval: 30          # increase metric frequency
   macos-power-metrics:
-    disabled: true  # Disable if root unavailable
+    disabled: true               # disable if root unavailable
   mac-perf-snapshots:
-    disabled: true  # Disable if no external collector is running
+    disabled: true               # disable if no external collector is running
 ```
 
 ## Installation
@@ -212,32 +210,6 @@ inputs:
    ```
 
 ## Fields
-
-### Memory Events (`macos:system:memory`)
-
-| Field | Type | Description |
-|-------|------|-------------|
-| pages_free | number | Free memory pages |
-| pages_active | number | Active memory pages |
-| pages_inactive | number | Inactive memory pages |
-| pages_wired | number | Wired (non-pageable) memory pages |
-| pages_compressed | number | Pages used by compressor |
-| memory_free_pct | number | System-wide memory free percentage |
-
-### WindowServer Events (`macos:system:windowserver`)
-
-| Field | Type | Description |
-|-------|------|-------------|
-| ping_timeout_events | number | Count of ping timeout events in sample window |
-| ping_timeout_pids | array | PIDs of processes that timed out on ping response |
-
-### Jetsam Events (`macos:system:jetsam`)
-
-| Field | Type | Description |
-|-------|------|-------------|
-| largestProcess | string | Process name consuming the most memory at time of Jetsam |
-| memoryStatus | object | System memory status including page counts and compressor stats |
-| processes | array | List of processes with memory details and states |
 
 ### Power Metrics Events (`macos:perf:powermetrics`)
 
@@ -263,38 +235,53 @@ inputs:
 | temperature | number | Battery temperature (hundredths of °C) |
 | voltage | number | Battery voltage (mV) |
 
+### Native Source Events
+
+The native `apple_unified_logs` and `system_metrics` Sources emit Cribl-defined event
+shapes — see Cribl's [MacOS System Metrics Details](https://docs.cribl.io/edge/system-metrics-macos-output)
+and [Apple Unified Logs Source](https://docs.cribl.io/edge/sources-apple-unified-logs)
+reference docs for the full field listings. Edge passes them through unchanged; Stream
+pipelines do downstream extraction.
+
 ### Common Fields (all sourcetypes)
 
 | Field | Type | Description |
 |-------|------|-------------|
-| index | string | `os` for system + battery sources; `mac_perf` for perf sources |
-| sourcetype | string | `macos:system:{type}`, `macos:power:battery`, `macos:perf:powermetrics`, or `macos:perf:snapshot` |
-| host | string | Hostname of the Edge node (or the snapshot event's `host` for file-source events) |
-| anomaly | boolean | `true` when anomaly detected (absent otherwise) |
-| anomaly_reason | string | Anomaly type identifier (absent when no anomaly) |
-
-## Future Roadmap
-
-- **Network statistics** (`netstat`, `nettop`, interface metrics)
-- **Firewall status** (`socketfilterfw --getglobalstate`)
-- **Login/auth events** (`log show` with auth predicates)
-- **Software update status** (`softwareupdate --list`)
-- **FileVault encryption status** (`fdesetup status`)
-- **SIP status** (`csrutil status`)
-- **Disk space** (`df -h`)
-- **System uptime and load** (`uptime`, `sysctl`)
-- **Open file descriptors** (`lsof` summary)
+| index | string | `os` for unified-log + thermal + battery; `mac_perf` for system metrics + powermetrics + snapshots |
+| sourcetype | string | See namespace table above |
+| host | string | Hostname of the Edge node |
+| anomaly | boolean | `true` when anomaly detected (exec sources only — see Anomaly Detection) |
+| anomaly_reason | string | Anomaly type identifier |
 
 ## Release Notes
 
+### v0.3.0 (2026-05-20)
+
+- **Native 4.18 Sources adopted**:
+  - `in_apple_unified_logs` (broad capture, `subsystem BEGINSWITH "com.apple"`)
+  - `in_system_metrics` (host CPU/memory/disk/network + process)
+- **Six exec inputs retired** in favor of the native Sources:
+  - `macos-memory-pressure`, `macos-vm-stat`, `macos-disk-io`, `macos-process-top`,
+    `macos-windowserver-health`, `macos-jetsam-events`
+- **Architecture shift**: Edge now captures broadly; Stream-side pipelines handle
+  per-use-case filtering. Anomaly detection for memory pressure / WindowServer pings /
+  Jetsam events moves to Stream (out of scope for this pack release).
+- **Three exec inputs retained**: `macos-thermal`, `macos-power-metrics`,
+  `macos-power-battery` — no 4.18 native equivalent.
+- **`minLogStreamVersion` bumped to `4.18.0`** (required for the new Source types).
+- **BREAKING** for v0.2 dashboards filtering `sourcetype=macos:system:memory|windowserver|jetsam|process|diskio|vmstat`
+  — those sourcetypes no longer exist on Edge. The equivalent data is now under
+  `macos:unified_log` and `macos:system:metrics`; rebuild downstream dashboards accordingly.
+
 ### v0.2.0 (2026-04-29)
 
-- **New File input** `mac-perf-snapshots` — tails NDJSON files emitted by an external snapshot
-  collector (such as `nix-mac-performance/monitoring/collect-snapshot.py`).
-  Reads `*.ndjson` from `$MAC_PERF_SNAPSHOTS_DIR`, parses each JSON line, sets `_time` from the
-  event's `ts` field, routes to `index=mac_perf` with sourcetype `macos:perf:snapshot`.
-- **Powermetrics retargeted** — the existing `macos-power-metrics` Exec input now writes to
-  `index=mac_perf` with sourcetype `macos:perf:powermetrics`.
+- **New File input** `mac-perf-snapshots` — tails NDJSON files emitted by an external
+  snapshot collector (such as `nix-mac-performance/monitoring/collect-snapshot.py`).
+  Reads `*.ndjson` from `$MAC_PERF_SNAPSHOTS_DIR`, parses each JSON line, sets `_time`
+  from the event's `ts` field, routes to `index=mac_perf` with sourcetype
+  `macos:perf:snapshot`.
+- **Powermetrics retargeted** — the existing `macos-power-metrics` Exec input now writes
+  to `index=mac_perf` with sourcetype `macos:perf:powermetrics`.
   **BREAKING** for any v0.1.0 dashboards or alerts that filtered
   `index=os sourcetype=macos:power:metrics`; update saved searches accordingly.
 - **New `perf` streamtag** added to pack metadata.
@@ -308,15 +295,20 @@ inputs:
 - **Prerequisites for v0.2.0:**
   - Splunk index `mac_perf` exists (provisioned by ansible-splunk).
   - Splunk add-on `VisiCore_TA_AI_Observability` includes `[macos:perf:snapshot]` and `[macos:perf:powermetrics]` props.
-  - For the file input to have data: a snapshot collector must be installed on the Mac (e.g., `nix-mac-performance` PR #2 LaunchAgent).
+  - For the file input to have data: a snapshot collector must be installed on the Mac
+    (e.g., `nix-mac-performance` PR #2 LaunchAgent).
   - Cribl Edge worker has `MAC_PERF_SNAPSHOTS_DIR` env var set.
 
 ### v0.1.0 (2026-04-18)
 
-- **Initial release** of `cc-edge-the-mac-pack-io` — consolidates `cc-edge-macos-system` and `cc-edge-macos-power` (both predecessor repos archived)
+- **Initial release** of `cc-edge-the-mac-pack-io` — consolidates `cc-edge-macos-system`
+  and `cc-edge-macos-power` (both predecessor repos archived).
 - **Nine Exec inputs**:
-  - System monitoring: WindowServer health (60s), memory pressure (60s), Jetsam events (5min),
-    process stats (60s), disk I/O (60s), VM stats (60s), thermal status (60s)
-  - Power monitoring: per-process energy metrics + thermal (300s), battery health (60s)
-- **Anomaly detection** for: memory pressure, WindowServer timeouts, Jetsam events, battery health degradation, thermal pressure elevation
-- **Sourcetype namespaces**: `macos:system:*` and `macos:power:*`
+  - System monitoring: WindowServer health (60s), memory pressure (60s),
+    Jetsam events (5min), process stats (60s), disk I/O (60s), VM stats (60s),
+    thermal status (60s)
+  - Power monitoring: per-process energy metrics + thermal (300s),
+    battery health (60s)
+- **Anomaly detection** for: memory pressure, WindowServer timeouts, Jetsam events,
+  battery health degradation, thermal pressure elevation.
+- **Sourcetype namespaces**: `macos:system:*` and `macos:power:*`.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ any other subsystem-of-interest) downstream.
 - **Index**: `mac_perf`
 - **Captures**: Per-process energy impact (top 10), CPU package power (mW), GPU power,
   ANE power, thermal pressure state, processor frequency
-- **Anomaly**: `thermal_pressure !== 'Nominal'` sets `anomaly=true`
+- **Anomaly**: `thermal.thermal_pressure !== 'Nominal'` sets `anomaly=true`
 - **Why exec**: No native 4.18 Source exposes per-process energy / ANE power.
 - **Requires**: Root privileges
 
@@ -238,7 +238,7 @@ inputs:
 ### Native Source Events
 
 The native `apple_unified_logs` and `system_metrics` Sources emit Cribl-defined event
-shapes — see Cribl's [MacOS System Metrics Details](https://docs.cribl.io/edge/system-metrics-macos-output)
+shapes — see Cribl's [macOS System Metrics Details](https://docs.cribl.io/edge/system-metrics-macos-output)
 and [Apple Unified Logs Source](https://docs.cribl.io/edge/sources-apple-unified-logs)
 reference docs for the full field listings. Edge passes them through unchanged; Stream
 pipelines do downstream extraction.

--- a/default/inputs.yml
+++ b/default/inputs.yml
@@ -1,76 +1,41 @@
 inputs:
-  macos-memory-pressure:
-    type: exec
+  # Native 4.18 Source: collects the macOS Unified Logging Subsystem broadly.
+  # Per-use-case filtering (WindowServer ping, Jetsam, security events, etc.)
+  # moves to Stream-side pipelines/routes — Edge captures, Stream filters.
+  # Replaces the v0.2 exec sources: macos-windowserver-health, macos-jetsam-events.
+  in_apple_unified_logs:
+    type: apple_unified_logs
     disabled: false
     sendToRoutes: true
     pqEnabled: false
     streamtags: []
-    command: "memory_pressure"
-    interval: 60
+    # NSPredicate. BEGINSWITH "com.apple" captures every Apple system subsystem
+    # (kernel, WindowServer, security, network, power, Spotlight, Time Machine,
+    # TCC, sandbox, etc.). Use TRUEPREDICATE if you also want 3rd-party app logs.
+    predicate: 'subsystem BEGINSWITH "com.apple"'
+    # Read only new entries on (re)start; switch to "allEvents" for a full backfill.
+    readMode: lastEntry
     metadata:
       - name: datatype
-        value: "'macos-system-memory'"
+        value: "'macos-unified-log'"
 
-  macos-windowserver-health:
-    type: exec
+  # Native 4.18 Source: collects host CPU/memory/network/disk + process metrics.
+  # Per-process / per-interface filtering moves to Stream.
+  # Replaces the v0.2 exec sources: macos-memory-pressure, macos-vm-stat,
+  # macos-disk-io, macos-process-top.
+  in_system_metrics:
+    type: system_metrics
     disabled: false
     sendToRoutes: true
     pqEnabled: false
     streamtags: []
-    command: "/usr/bin/log show --last 65s --predicate 'process == \"WindowServer\" AND eventMessage CONTAINS \"ping\"' --style json"
-    interval: 60
+    pollingInterval: 60
     metadata:
       - name: datatype
-        value: "'macos-system-windowserver'"
+        value: "'macos-system-metrics'"
 
-  macos-jetsam-events:
-    type: exec
-    disabled: false
-    sendToRoutes: true
-    pqEnabled: false
-    streamtags: []
-    command: "/bin/bash -c 'f=$(ls -t /Library/Logs/DiagnosticReports/JetsamEvent-*.ips 2>/dev/null | head -1); if [ -n \"$f\" ]; then ts=$(stat -f %m \"$f\"); now=$(date +%s); age=$((now - ts)); if [ $age -le 300 ]; then tail -n +2 \"$f\"; else echo \"{\\\"no_recent_jetsam\\\":true}\"; fi; else echo \"{\\\"no_recent_jetsam\\\":true}\"; fi'"
-    interval: 300
-    metadata:
-      - name: datatype
-        value: "'macos-system-jetsam'"
-
-  macos-process-top:
-    type: exec
-    disabled: false
-    sendToRoutes: true
-    pqEnabled: false
-    streamtags: []
-    command: "top -l 1 -n 20 -stats pid,command,cpu,mem,rprvt,purg,vsize,threads"
-    interval: 60
-    metadata:
-      - name: datatype
-        value: "'macos-system-process'"
-
-  macos-disk-io:
-    type: exec
-    disabled: false
-    sendToRoutes: true
-    pqEnabled: false
-    streamtags: []
-    command: "iostat -d -c 2 -w 1"
-    interval: 60
-    metadata:
-      - name: datatype
-        value: "'macos-system-diskio'"
-
-  macos-vm-stat:
-    type: exec
-    disabled: false
-    sendToRoutes: true
-    pqEnabled: false
-    streamtags: []
-    command: "vm_stat"
-    interval: 60
-    metadata:
-      - name: datatype
-        value: "'macos-system-vmstat'"
-
+  # Exec source — no native 4.18 equivalent (pmset surfaces system-wide thermal
+  # pressure that the System Metrics Source doesn't yet report on macOS).
   macos-thermal:
     type: exec
     disabled: false
@@ -83,6 +48,8 @@ inputs:
       - name: datatype
         value: "'macos-system-thermal'"
 
+  # Exec source — no native 4.18 equivalent.
+  # powermetrics is the only path to per-process energy / CPU/GPU/ANE power.
   macos-power-metrics:
     type: exec
     disabled: false
@@ -95,6 +62,8 @@ inputs:
       - name: datatype
         value: "'macos-power-metrics'"
 
+  # Exec source — no native 4.18 equivalent.
+  # Battery cycle count, max capacity, voltage etc. only come from ioreg/pmset.
   macos-power-battery:
     type: exec
     disabled: false
@@ -107,6 +76,8 @@ inputs:
       - name: datatype
         value: "'macos-power-battery'"
 
+  # File source — collect-snapshot.py drops NDJSON perf snapshots here.
+  # Separate data product from the native Sources; kept as-is.
   mac-perf-snapshots:
     type: file
     disabled: false

--- a/default/pipelines/main.yml
+++ b/default/pipelines/main.yml
@@ -14,9 +14,9 @@ conf:
       conf:
         add:
           - name: index
-            value: "(datatype === 'macos-power-metrics' || datatype === 'macos-perf-snapshot' || datatype === 'macos-system-metrics') ? 'mac_perf' : 'os'"
+            value: "['macos-power-metrics', 'macos-perf-snapshot', 'macos-system-metrics'].includes(datatype) ? 'mac_perf' : 'os'"
           - name: sourcetype
-            value: "datatype === 'macos-power-metrics' ? 'macos:perf:powermetrics' : (datatype === 'macos-perf-snapshot' ? 'macos:perf:snapshot' : (datatype === 'macos-unified-log' ? 'macos:unified_log' : (datatype === 'macos-system-metrics' ? 'macos:system:metrics' : (datatype ? datatype.replace('macos-power-', 'macos:power:').replace('macos-system-', 'macos:system:') : ''))))"
+            value: "datatype === 'macos-power-metrics' ? 'macos:perf:powermetrics' : (datatype === 'macos-perf-snapshot' ? 'macos:perf:snapshot' : (datatype === 'macos-unified-log' ? 'macos:unified_log' : (datatype ? datatype.replace('macos-power-', 'macos:power:').replace('macos-system-', 'macos:system:') : '')))"
           - name: host
             value: "host || C.os.hostname()"
     - id: eval

--- a/default/pipelines/main.yml
+++ b/default/pipelines/main.yml
@@ -14,9 +14,9 @@ conf:
       conf:
         add:
           - name: index
-            value: "(datatype === 'macos-power-metrics' || datatype === 'macos-perf-snapshot') ? 'mac_perf' : 'os'"
+            value: "(datatype === 'macos-power-metrics' || datatype === 'macos-perf-snapshot' || datatype === 'macos-system-metrics') ? 'mac_perf' : 'os'"
           - name: sourcetype
-            value: "datatype === 'macos-power-metrics' ? 'macos:perf:powermetrics' : (datatype === 'macos-perf-snapshot' ? 'macos:perf:snapshot' : (datatype ? datatype.replace('macos-power-', 'macos:power:').replace('macos-system-', 'macos:system:') : ''))"
+            value: "datatype === 'macos-power-metrics' ? 'macos:perf:powermetrics' : (datatype === 'macos-perf-snapshot' ? 'macos:perf:snapshot' : (datatype === 'macos-unified-log' ? 'macos:unified_log' : (datatype === 'macos-system-metrics' ? 'macos:system:metrics' : (datatype ? datatype.replace('macos-power-', 'macos:power:').replace('macos-system-', 'macos:system:') : ''))))"
           - name: host
             value: "host || C.os.hostname()"
     - id: eval
@@ -26,32 +26,6 @@ conf:
         add:
           - name: _time
             value: "C.Time.parse(ts)"
-    - id: eval
-      filter: "datatype === 'macos-system-memory'"
-      disabled: false
-      conf:
-        add:
-          - name: pages_free
-            value: "Number((_raw.match(/Pages free:\\s+(\\d+)/)||[])[1]) || 0"
-          - name: pages_active
-            value: "Number((_raw.match(/Pages active:\\s+(\\d+)/)||[])[1]) || 0"
-          - name: pages_inactive
-            value: "Number((_raw.match(/Pages inactive:\\s+(\\d+)/)||[])[1]) || 0"
-          - name: pages_wired
-            value: "Number((_raw.match(/Pages wired down:\\s+(\\d+)/)||[])[1]) || 0"
-          - name: pages_compressed
-            value: "Number((_raw.match(/Pages used by compressor:\\s+(\\d+)/)||[])[1]) || 0"
-          - name: memory_free_pct
-            value: "Number((_raw.match(/System-wide memory free percentage:\\s+(\\d+)%/)||[])[1]) || 0"
-    - id: eval
-      filter: "datatype === 'macos-system-windowserver'"
-      disabled: false
-      conf:
-        add:
-          - name: ping_timeout_events
-            value: "Array.isArray(__e) ? __e.filter(e => e.eventMessage && e.eventMessage.includes('ping')).length : (typeof _raw === 'string' && _raw.includes('ping') ? (_raw.match(/pid \\d+/g)||[]).length : 0)"
-          - name: ping_timeout_pids
-            value: "Array.isArray(__e) ? __e.map(e => (e.eventMessage.match(/pid (\\d+)/)||[])[1]).filter(Boolean) : (typeof _raw === 'string' ? (_raw.match(/pid (\\d+)/g)||[]).map(s => s.replace('pid ','')) : [])"
     - id: eval
       filter: "datatype === 'macos-power-battery'"
       disabled: false
@@ -72,6 +46,6 @@ conf:
       conf:
         add:
           - name: anomaly
-            value: "(datatype === 'macos-system-memory' && memory_free_pct < 10) || (datatype === 'macos-system-windowserver' && ping_timeout_events > 0) || (datatype === 'macos-system-jetsam' && !no_recent_jetsam) || (datatype === 'macos-power-battery' && battery_health_percent !== undefined && battery_health_percent < 80) || (datatype === 'macos-power-metrics' && thermal?.thermal_pressure !== undefined && thermal.thermal_pressure !== 'Nominal') ? true : undefined"
+            value: "(datatype === 'macos-power-battery' && battery_health_percent !== undefined && battery_health_percent < 80) || (datatype === 'macos-power-metrics' && thermal?.thermal_pressure !== undefined && thermal.thermal_pressure !== 'Nominal') ? true : undefined"
           - name: anomaly_reason
-            value: "(datatype === 'macos-system-memory' && memory_free_pct < 10) ? 'memory_pressure_critical' : (datatype === 'macos-system-windowserver' && ping_timeout_events > 0) ? 'windowserver_ping_timeout' : (datatype === 'macos-system-jetsam' && !no_recent_jetsam) ? 'jetsam_event_detected' : (datatype === 'macos-power-battery' && battery_health_percent !== undefined && battery_health_percent < 80) ? 'battery_health_degraded' : (datatype === 'macos-power-metrics' && thermal?.thermal_pressure !== undefined && thermal.thermal_pressure !== 'Nominal') ? 'thermal_pressure_elevated' : undefined"
+            value: "(datatype === 'macos-power-battery' && battery_health_percent !== undefined && battery_health_percent < 80) ? 'battery_health_degraded' : (datatype === 'macos-power-metrics' && thermal?.thermal_pressure !== undefined && thermal.thermal_pressure !== 'Nominal') ? 'thermal_pressure_elevated' : undefined"

--- a/default/pipelines/route.yml
+++ b/default/pipelines/route.yml
@@ -2,64 +2,24 @@ id: default
 groups: {}
 comments: []
 routes:
-  - id: windowserver-health
-    name: WindowServer Health (Exec Source)
+  - id: apple-unified-logs
+    name: Apple Unified Logs (Native 4.18 Source)
     final: true
     disabled: false
     pipeline: main
-    description: "macOS WindowServer ping timeout events (UI freeze detection)"
+    description: "macOS Apple Unified Logs — broad capture (subsystem BEGINSWITH com.apple); Stream filters per use case"
     enableOutputExpression: false
-    filter: __inputId=='exec:cc-edge-the-mac-pack-io.macos-windowserver-health'
+    filter: __inputId=='apple_unified_logs:cc-edge-the-mac-pack-io.in_apple_unified_logs'
     clones: []
     output: default
-  - id: memory-pressure
-    name: Memory Pressure (Exec Source)
+  - id: system-metrics
+    name: System Metrics (Native 4.18 Source)
     final: true
     disabled: false
     pipeline: main
-    description: "macOS memory pressure stats (pages, swap, compressor, free percentage)"
+    description: "macOS System Metrics — CPU/memory/disk/network/process; Stream filters per use case"
     enableOutputExpression: false
-    filter: __inputId=='exec:cc-edge-the-mac-pack-io.macos-memory-pressure'
-    clones: []
-    output: default
-  - id: jetsam-events
-    name: Jetsam Events (Exec Source)
-    final: true
-    disabled: false
-    pipeline: main
-    description: "macOS Jetsam memory kill events from DiagnosticReports"
-    enableOutputExpression: false
-    filter: __inputId=='exec:cc-edge-the-mac-pack-io.macos-jetsam-events'
-    clones: []
-    output: default
-  - id: process-top
-    name: Process Stats (Exec Source)
-    final: true
-    disabled: false
-    pipeline: main
-    description: "macOS top process statistics (CPU, memory, threads)"
-    enableOutputExpression: false
-    filter: __inputId=='exec:cc-edge-the-mac-pack-io.macos-process-top'
-    clones: []
-    output: default
-  - id: disk-io
-    name: Disk I/O (Exec Source)
-    final: true
-    disabled: false
-    pipeline: main
-    description: "macOS disk I/O statistics (throughput, transactions, bandwidth)"
-    enableOutputExpression: false
-    filter: __inputId=='exec:cc-edge-the-mac-pack-io.macos-disk-io'
-    clones: []
-    output: default
-  - id: vm-stat
-    name: VM Statistics (Exec Source)
-    final: true
-    disabled: false
-    pipeline: main
-    description: "macOS virtual memory statistics (page faults, compressor, swap)"
-    enableOutputExpression: false
-    filter: __inputId=='exec:cc-edge-the-mac-pack-io.macos-vm-stat'
+    filter: __inputId=='system_metrics:cc-edge-the-mac-pack-io.in_system_metrics'
     clones: []
     output: default
   - id: thermal
@@ -67,7 +27,7 @@ routes:
     final: true
     disabled: false
     pipeline: main
-    description: "macOS thermal and performance warning levels"
+    description: "macOS thermal and performance warning levels (pmset -g therm)"
     enableOutputExpression: false
     filter: __inputId=='exec:cc-edge-the-mac-pack-io.macos-thermal'
     clones: []

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "cc-edge-the-mac-pack-io",
-  "version": "0.2.0",
-  "minLogStreamVersion": "4.16.0",
+  "version": "0.3.0",
+  "minLogStreamVersion": "4.18.0",
   "author": "VisiCore Tech - CriblPacks@VisiCoreTech.com",
-  "description": "Cribl Edge Pack for comprehensive macOS system, power, and performance telemetry: memory pressure, WindowServer health, Jetsam events, process stats, disk I/O, VM stats, thermal status, ANE/GPU/CPU power metrics, battery health, and full perf snapshots — with anomaly detection.",
+  "description": "Cribl Edge Pack for comprehensive macOS system, power, and performance telemetry: native Apple Unified Logs and System Metrics sources (4.18+), plus exec-based powermetrics, battery health, thermal, and perf snapshots — with anomaly detection.",
   "displayName": "The Mac Pack — macOS System, Power & Performance Monitoring for Edge",
   "tags": {
     "streamtags": ["vct", "macos", "system", "power", "battery", "perf", "monitoring"],


### PR DESCRIPTION
## Summary

- Replace 6 exec sources with 2 broad-capture native 4.18 sources (Apple Unified Logs + System Metrics)
- Keep 3 exec sources where 4.18 has no native equivalent (powermetrics, battery, thermal)
- Bump minLogStreamVersion 4.16.0 → 4.18.0
- Move per-use-case filtering (WindowServer ping detection, Jetsam triage, memory anomalies) out of the Edge pack; Stream pipelines will handle that downstream (deferred)

## Architecture

Edge captures broadly; Stream filters. The Apple Unified Logs Source uses `subsystem BEGINSWITH "com.apple"` so the entire Apple system log stream lands in Edge unfiltered. The narrow exec predicates from v0.2 (`process == "WindowServer" AND eventMessage CONTAINS "ping"` etc.) are gone — Stream-side routing/pipelines will re-extract those signals from the broad capture.

## Files changed

- `default/inputs.yml` — 6 exec sources removed, 2 native sources added
- `default/pipelines/route.yml` — collapsed routing
- `default/pipelines/main.yml` — dropped exec-specific parsing for the removed sources; kept battery + powermetrics + perf-snapshot logic
- `package.json` — version 0.3.0, minLogStreamVersion 4.18.0
- `README.md` — overhauled docs + v0.3.0 release notes

## Breaking changes

Dashboards filtering on these v0.2 sourcetypes will see no data after deploy:

- `macos:system:memory`
- `macos:system:windowserver`
- `macos:system:jetsam`
- `macos:system:process`
- `macos:system:diskio`
- `macos:system:vmstat`

The equivalent data is now under `macos:unified_log` (logs) and `macos:system:metrics` (metrics). Rebuild affected saved searches.

## Verification

- [x] Shared `_cribl-pack-validate.yml@main` workflow Tier 1-4 (23 tests) pass locally
- [ ] CI run on this PR (auto)
- [ ] Pack loads cleanly on a 4.18 Edge node (post-merge, when Cribl Cloud auth is re-enrolled — that's blocked separately)

## Test plan

- [ ] Build v0.3.0 .crbl from main after merge
- [ ] Install on macbook-m4's Cribl 4.18 Edge
- [ ] Confirm Apple Unified Logs Source + System Metrics Source emit events
- [ ] Confirm exec sources (powermetrics, battery, thermal) still emit
- [ ] Verify events land in Splunk `os` and `mac_perf` indexes with new sourcetypes

🤖 Generated with [Claude Code](https://claude.com/claude-code)