### PR TITLE
docs(readme): add ecosystem footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,3 +312,7 @@ pipelines do downstream extraction.
 - **Anomaly detection** for: memory pressure, WindowServer timeouts, Jetsam events,
   battery health degradation, thermal pressure elevation.
 - **Sourcetype namespaces**: `macos:system:*` and `macos:power:*`.
+
+---
+
+> Part of a [larger ecosystem of ~40 repos](https://docs.jacobpevans.com) — see how it all fits together.


### PR DESCRIPTION
## Summary
- Add the standard docs.jacobpevans.com ecosystem footer to README.md, matching the format used across other public repos.

## Test plan
- [x] Docs only, no functional change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pj9ZFKDR2iCis44dC2y8Hu